### PR TITLE
Criado flake.nix para fácil reprodução

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,16 @@
+{
+  outputs = { nixpkgs, ... }: {
+    devShells.x86_64-linux.default = let
+      pkgs = import nixpkgs {
+        system = "x86_64-linux";
+  	    config.allowUnfree = true;
+      };
+    in
+      pkgs.mkShell {
+        name = "SCTI-Web";
+        packages = with pkgs; [
+          go
+        ]
+      };
+  };
+}


### PR DESCRIPTION
Criado flake.nix básico, precisa ser compilado para gerar flake.lock