### PR TITLE
Mudanças feitas no flake.nix e atualizações

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,16 +2,18 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1710129248,
-        "narHash": "sha256-bWF8ZEL5VHS+mLXrd4kpe4QnthMvxXofjMzFd9yG5gs=",
-        "owner": "NixOS",
+        "lastModified": 1711001935,
+        "narHash": "sha256-URtGpHue7HHZK0mrHnSf8wJ6OmMKYSsoLmJybrOLFSQ=",
+        "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "8c4e5e571696d4c476881cf90257c3dd0e66b0dd",
+        "rev": "20f77aa09916374aa3141cbc605c955626762c9a",
         "type": "github"
       },
       "original": {
-        "id": "nixpkgs",
-        "type": "indirect"
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
       }
     },
     "root": {

--- a/flake.nix
+++ b/flake.nix
@@ -7,14 +7,18 @@
     devShells.x86_64-linux.default = let
       pkgs = import nixpkgs {
         system = "x86_64-linux";
-  	config.allowUnfree = true;
+        config.allowUnfree = true;
       };
     in
       pkgs.mkShell {
         name = "SCTI-Web";
         packages = with pkgs; [
+          fish
           go
         ];
+        shellHook = ''
+          fish
+        '';
       };
   };
 }

--- a/flake.nix
+++ b/flake.nix
@@ -1,9 +1,13 @@
 {
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
+  };
+
   outputs = { nixpkgs, ... }: {
     devShells.x86_64-linux.default = let
       pkgs = import nixpkgs {
         system = "x86_64-linux";
-  	    config.allowUnfree = true;
+  	config.allowUnfree = true;
       };
     in
       pkgs.mkShell {

--- a/src/go.mod
+++ b/src/go.mod
@@ -1,5 +1,5 @@
 module SCTI
 
-go 1.21.5
+go 1.22.1
 
 require github.com/gorilla/mux v1.8.1

--- a/src/main.go
+++ b/src/main.go
@@ -1,23 +1,23 @@
 package main
 
 import (
+	"SCTI/about"
+	"SCTI/fileserver"
+	"html/template"
 	"log"
 	"net/http"
-  "html/template"
-  "SCTI/about"
-  "SCTI/fileserver"
 )
 
 func main() {
-  fileserver.RunFileServer()
+	fileserver.RunFileServer()
 
-  http.HandleFunc("/", HomeHandler)
-  http.HandleFunc("/home/", about.Endpoint)
+	http.HandleFunc("/", HomeHandler)
+	http.HandleFunc("/home/", about.Endpoint)
 
-  log.Fatal(http.ListenAndServe(":8080", nil))
+	log.Fatal(http.ListenAndServe(":8080", nil))
 }
 
 func HomeHandler(w http.ResponseWriter, r *http.Request) {
-  fileserver.T = template.Must(template.ParseFiles("template/index.gohtml"))
-  fileserver.T.Execute(w, nil)
+	fileserver.T = template.Must(template.ParseFiles("template/index.gohtml"))
+	fileserver.T.Execute(w, nil)
 }


### PR DESCRIPTION
- Um `shellHook` foi adicionado para assim que você entrar na shell ela te colocar no fish
- A versão da linguagem go foi atualizada para 1.22.1
- A versão do nixpkgs usada no flake agora é `nixpkgs-unstable`