### PR TITLE
Feat/supabase

### DIFF
--- a/src/main.go
+++ b/src/main.go
@@ -21,7 +21,7 @@ func start() (*supabase.Client) {
   conf := supabase.Config{
     ApiKey:     os.Getenv("SUPABASE_KEY"), 
     ProjectRef: os.Getenv("SUPABASE_URL"),
-    Debug:      true,
+    Debug:      false,
   }
   supaClient, err := supabase.New(conf)
   if err != nil {

--- a/src/rotas/auth/handler.go
+++ b/src/rotas/auth/handler.go
@@ -45,9 +45,6 @@ func (h *Handler) PostSignup(w http.ResponseWriter, r *http.Request) {
     user.Password = r.FormValue("Senha")
   }
 
-  fmt.Println(user.Email)
-  fmt.Println(user.Password)
-
   body := dto.SignUpRequest{
     Email:    user.Email,
     Password: user.Password,

--- a/src/rotas/auth/handler.go
+++ b/src/rotas/auth/handler.go
@@ -19,9 +19,15 @@ type User struct {
   Password string 
 }
 
+type SupaError struct {
+	Code      int    `json:"code"`
+	ErrorCode string `json:"error_code"`
+	Msg       string `json:"msg"`
+}
+
 func (h *Handler) PostSignup(w http.ResponseWriter, r *http.Request) {
-  ctx := r.Context()
   println("In PostSignup")
+  ctx := r.Context()
 
   var user User
 
@@ -35,8 +41,8 @@ func (h *Handler) PostSignup(w http.ResponseWriter, r *http.Request) {
       fmt.Println("r.Form dentro if: ", r.Form)
       log.Fatal(err)
     }
-    user.Email = r.FormValue("Nome")
-    user.Password = r.FormValue("Idade")
+    user.Email = r.FormValue("Email")
+    user.Password = r.FormValue("Senha")
   }
 
   fmt.Println(user.Email)
@@ -48,14 +54,46 @@ func (h *Handler) PostSignup(w http.ResponseWriter, r *http.Request) {
   }
 
   _, err := h.S.Auth.SignUp(ctx, body)
-  if err == nil {
-    panic("Panicked at PostSignup")
-  } else {
-    fmt.Printf("We signed up?")
+  if err != nil {
+    // Check if the error is of type SupaError
+    var supaErr SupaError
+    if jsonErr := json.Unmarshal([]byte(err.Error()), &supaErr); jsonErr == nil {
+      switch supaErr.ErrorCode {
+      case "user_already_exists":
+        http.Error(w, "User already registered", http.StatusConflict)
+        return
+      case "anonymous_provider_disabled":
+        http.Error(w, "Anonymous sign-ins are disabled", http.StatusForbidden)
+        return
+      default:
+        http.Error(w, fmt.Sprintf("Error signing up: %v", supaErr.Msg), http.StatusInternalServerError)
+        return
+      }
+    }
+    // Handle generic error if unable to parse SupaError
+    http.Error(w, fmt.Sprintf("Request error: %v", err), http.StatusInternalServerError)
+    return
   }
+
+  // Read the successful response if needed
+  // var authDetail AuthDetailResp
+  // bodyBytes, readErr := ioutil.ReadAll(resp.Body)
+  // if readErr != nil {
+  //     http.Error(w, fmt.Sprintf("Failed to read response body: %v", readErr), http.StatusInternalServerError)
+  //     return
+  // }
+  // jsonErr := json.Unmarshal(bodyBytes, &authDetail)
+  // if jsonErr != nil {
+  //     http.Error(w, fmt.Sprintf("Failed to parse success response: %v", jsonErr), http.StatusInternalServerError)
+  //     return
+  // }
+
+  // Redirect to the lncc page after successful signup
+  http.Redirect(w, r, "/lncc", http.StatusSeeOther)
 }
 
 func (h *Handler) GetSignup(w http.ResponseWriter, r *http.Request) {
+  println("In GetSignup")
   var t = fileserver.Execute("template/signup.gohtml")
   t.Execute(w, nil)
 }
@@ -67,6 +105,6 @@ func (h *Handler) GetLogin(w http.ResponseWriter, r *http.Request) {
 func RegisterRoutes(mux *http.ServeMux, s *supabase.Client) {
   handler := &Handler{S: s}
   mux.HandleFunc("GET /signup", handler.GetSignup)
-  mux.HandleFunc("POST /signup", handler.GetSignup)
+  mux.HandleFunc("POST /signup", handler.PostSignup)
   mux.HandleFunc("/login", handler.GetLogin)
 }

--- a/src/rotas/auth/handler.go
+++ b/src/rotas/auth/handler.go
@@ -1,13 +1,14 @@
 package auth
 
 import (
-  "fmt"
-  "log"
-  "net/http"
-  "encoding/json"
-  "SCTI/fileserver"
-  "github.com/lengzuo/supa"
-  "github.com/lengzuo/supa/dto"
+	"SCTI/fileserver"
+	"encoding/json"
+	"fmt"
+	"log"
+	"net/http"
+
+	"github.com/lengzuo/supa"
+	"github.com/lengzuo/supa/dto"
 )
 
 type Handler struct{
@@ -86,7 +87,7 @@ func (h *Handler) PostSignup(w http.ResponseWriter, r *http.Request) {
   // }
 
   // Redirect to the lncc page after successful signup
-  http.Redirect(w, r, "/lncc", http.StatusSeeOther)
+  http.Redirect(w, r, "/login", http.StatusSeeOther)
 }
 
 func (h *Handler) GetSignup(w http.ResponseWriter, r *http.Request) {
@@ -95,13 +96,86 @@ func (h *Handler) GetSignup(w http.ResponseWriter, r *http.Request) {
   t.Execute(w, nil)
 }
 
+func (h *Handler) PostLogin(w http.ResponseWriter, r *http.Request) {
+  fmt.Println("In PostLogin")
+  ctx := r.Context()
+
+  var user User
+
+  if r.Header.Get("Content-type") == "application/json" {
+    err := json.NewDecoder(r.Body).Decode(&user)
+    if err != nil {
+      log.Fatal(err)
+    }
+  } else {
+    if err := r.ParseForm(); err != nil {
+      fmt.Println("r.Form dentro if: ", r.Form)
+      log.Fatal(err)
+    }
+    user.Email = r.FormValue("Email")
+    user.Password = r.FormValue("Senha")
+  }
+
+  body := dto.SignInRequest{
+    Email:    user.Email,
+    Password: user.Password,
+  }
+
+  _, err := h.S.Auth.SignInWithPassword(ctx, body)
+  if err != nil {
+    // Check if the error is of type SupaError
+    var supaErr SupaError
+    if jsonErr := json.Unmarshal([]byte(err.Error()), &supaErr); jsonErr == nil {
+      switch supaErr.ErrorCode {
+      case "invalid_credentials":
+        http.Error(w, "Invalid email or password", http.StatusUnauthorized)
+        return
+      case "user_not_found":
+        http.Error(w, "User not found", http.StatusNotFound)
+        return
+      case "anonymous_provider_disabled":
+        http.Error(w, "Anonymous sign-ins are disabled", http.StatusForbidden)
+        return
+      default:
+        http.Error(w, fmt.Sprintf("Error signing in: %v", supaErr.Msg), http.StatusInternalServerError)
+        return
+    }
+    }
+    // Handle generic error if unable to parse SupaError
+    http.Error(w, fmt.Sprintf("Request error: %v", err), http.StatusInternalServerError)
+    return
+  }
+
+  // Read the successful response if needed
+  // var authDetail AuthDetailResp
+  // bodyBytes, readErr := ioutil.ReadAll(resp.Body)
+  // if readErr != nil {
+  //     http.Error(w, fmt.Sprintf("Failed to read response body: %v", readErr), http.StatusInternalServerError)
+  //     return
+  // }
+  // jsonErr := json.Unmarshal(bodyBytes, &authDetail)
+  // if jsonErr != nil {
+  //     http.Error(w, fmt.Sprintf("Failed to parse success response: %v", jsonErr), http.StatusInternalServerError)
+  //     return
+  // }
+
+  // Redirect to the lncc page after successful signup
+  http.Redirect(w, r, "/lncc", http.StatusSeeOther)
+
+}
+
 func (h *Handler) GetLogin(w http.ResponseWriter, r *http.Request) {
-  fmt.Fprintf(w, "Pagina de login")
+  println("In GetLogin")
+  var t = fileserver.Execute("template/login.gohtml")
+  t.Execute(w, nil)
 }
 
 func RegisterRoutes(mux *http.ServeMux, s *supabase.Client) {
   handler := &Handler{S: s}
+
   mux.HandleFunc("GET /signup", handler.GetSignup)
+  mux.HandleFunc("GET /login", handler.GetLogin)
+
   mux.HandleFunc("POST /signup", handler.PostSignup)
-  mux.HandleFunc("/login", handler.GetLogin)
+  mux.HandleFunc("POST /login", handler.PostLogin)
 }

--- a/src/template/login.gohtml
+++ b/src/template/login.gohtml
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>SCTI - Login</title>
+  </head>
+  <body>
+    <div>
+      <form method="POST" action="/login">
+        <table>
+          <tr>
+            <td><label>Email</label></td>
+            <td><input name="Email" type="email"></td>
+          </tr>
+
+          <tr>
+            <td><label>Senha</label></td>
+            <td><input name="Senha" type="password"></td>
+          </tr>
+        </table>
+        <br>
+        <input type="submit" value="Enviar">
+      </form>
+    </div>
+  </body>
+</html>


### PR DESCRIPTION
Signups através de Email já estão funcionando, porém o tratamento de erro está bem simples, precisamos de:
- [ ] Fazer o HTML e CSS basico da pagina para depois implementar o design
- [ ] Pegar o erro recibido e em vez de recarregar a pagina com o valor do erro, mostrar ele na pagina no local pertinente
  - Se o erro for de senha mostrar na caixa da senha
  - Se o erro for de usuario mostrar na caixa de usuario 
  - ETC
- [x] Lembrar o usuario que está logado de alguma maneira (Cookies?)
- [x] fazer uma pagina de login e implementar o login com Supabase nela
- [x] re-encaminhar o usuario apos o login para um dashboard
- [x] impedir que usuários que não estejam logados acessem o dashboard
- [ ] autmoaticamente logar o usuario apos signup com sucesso e re-encaminhar para dashboard
- [ ] (Futuro) Implementar login com o google quando todo o resto estiver funcionando